### PR TITLE
Give the next invasion bar a proper duration

### DIFF
--- a/BFAInvasionTimer.lua
+++ b/BFAInvasionTimer.lua
@@ -223,7 +223,7 @@ do
 		elseif rewardQuestID > 0 then -- Invasion duration bars
 			bar:Start(25200) -- 7hrs = 60*6 = 420min = 420*60 = 25,200sec
 		else -- Next invasion bars
-			bar:Start()
+			bar:Start(43200) -- 12hrs = 60*12 = 720min = 720*60 = 43,200sec
 		end
 		RearrangeBar()
 		if hiddenBars then


### PR DESCRIPTION
Noticed the duration was always based on the time left when logging in. Adding this provides some sense of scale of how much time until the next one. 