### PR TITLE
Assault order, warmode, and icon changes

### DIFF
--- a/BFAInvasionTimer.toc
+++ b/BFAInvasionTimer.toc
@@ -1,5 +1,5 @@
 ## Interface: 80100
-## Version: @project-version@
+## Version: v8.1.2
 ## Title: BFAInvasionTimer
 ## Author: Funkydude
 ## Notes: Shows the Battle for Azeroth assault/invasion timer.
@@ -13,7 +13,7 @@
 ## Notes-koKR: Shows the Battle for Azeroth assault/invasion timer.
 ## Notes-ptBR: Shows the Battle for Azeroth assault/invasion timer.
 ## Notes-ruRU: Shows the Battle for Azeroth assault/invasion timer.
-## SavedVariables: BFAInvasionTimerDB, BFAInvasionTime
+## SavedVariables: BFAInvasionTimerDB, BFAInvasionTime, BFAInvasionZone
 
 ## X-Category: Miscellaneous
 ## X-Website: https://github.com/funkydude/BFAInvasionTimer

--- a/BFAInvasionTimer.toc
+++ b/BFAInvasionTimer.toc
@@ -1,5 +1,5 @@
 ## Interface: 80100
-## Version: v8.1.2
+## Version: @project-version@
 ## Title: BFAInvasionTimer
 ## Author: Funkydude
 ## Notes: Shows the Battle for Azeroth assault/invasion timer.

--- a/Locales/deDE.lua
+++ b/Locales/deDE.lua
@@ -4,7 +4,7 @@ local _, mod = ...
 local L = mod.L
 
 L.firstRunWarning = "Timer werden erst angezeigt, sobald du die erste Invasion siehst."
-L.underAttack = "|T236292:15:15:0:0:64:64:4:60:4:60|t %s wird angegriffen!"
+L.underAttack = "|T1044517:15:15:0:0:64:64:4:60:4:60|t %s wird angegriffen!"
 L.nextInvasions = "Nächsten Invasionen"
 L.next = "Nächste"
 L.waiting = "Warten"

--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -4,7 +4,7 @@ mod.L = {}
 local L = mod.L
 
 L.firstRunWarning = "Timers will not be shown until you see your first invasion."
-L.underAttack = "|T236292:15:15:0:0:64:64:4:60:4:60|t %s is under attack!"
+L.underAttack = "|T1044517:15:15:0:0:64:64:4:60:4:60|t %s is under attack!"
 L.nextInvasions = "Next Invasions"
 L.next = "Next"
 L.waiting = "Waiting"

--- a/Locales/esES.lua
+++ b/Locales/esES.lua
@@ -4,7 +4,7 @@ local _, mod = ...
 local L = mod.L
 
 L.firstRunWarning = "Los tiempos no se mostrarán hasta que veas tu primera invasión"
-L.underAttack = "¡Están atacando |T236292:15:15:0:0:64:64:4:60:4:60|t %s!"
+L.underAttack = "¡Están atacando |T1044517:15:15:0:0:64:64:4:60:4:60|t %s!"
 L.nextInvasions = "Siguientes Invasiones"
 L.next = "Siguiente"
 L.waiting = "Esperando"

--- a/Locales/frFR.lua
+++ b/Locales/frFR.lua
@@ -4,7 +4,7 @@ local _, mod = ...
 local L = mod.L
 
 --L.firstRunWarning = "Timers will not be shown until you see your first invasion."
---L.underAttack = "|T236292:15:15:0:0:64:64:4:60:4:60|t %s is under attack!"
+--L.underAttack = "|T1044517:15:15:0:0:64:64:4:60:4:60|t %s is under attack!"
 --L.nextInvasions = "Next Invasions"
 --L.next = "Next"
 --L.waiting = "Waiting"

--- a/Locales/itIT.lua
+++ b/Locales/itIT.lua
@@ -4,7 +4,7 @@ local _, mod = ...
 local L = mod.L
 
 --L.firstRunWarning = "Timers will not be shown until you see your first invasion."
---L.underAttack = "|T236292:15:15:0:0:64:64:4:60:4:60|t %s is under attack!"
+--L.underAttack = "|T1044517:15:15:0:0:64:64:4:60:4:60|t %s is under attack!"
 --L.nextInvasions = "Next Invasions"
 --L.next = "Next"
 --L.waiting = "Waiting"

--- a/Locales/koKR.lua
+++ b/Locales/koKR.lua
@@ -4,7 +4,7 @@ local _, mod = ...
 local L = mod.L
 
 L.firstRunWarning = "타이머는 첫번째 침공을 확인하기 전까지 표시되지 않습니다."
-L.underAttack = "|T236292:15:15:0:0:64:64:4:60:4:60|t %s|1이;가; 공격받고 있습니다!"
+L.underAttack = "|T1044517:15:15:0:0:64:64:4:60:4:60|t %s|1이;가; 공격받고 있습니다!"
 L.nextInvasions = "다음 침공"
 L.next = "다음"
 L.waiting = "대기 중"

--- a/Locales/ptBR.lua
+++ b/Locales/ptBR.lua
@@ -4,7 +4,7 @@ local _, mod = ...
 local L = mod.L
 
 --L.firstRunWarning = "Timers will not be shown until you see your first invasion."
---L.underAttack = "|T236292:15:15:0:0:64:64:4:60:4:60|t %s is under attack!"
+--L.underAttack = "|T1044517:15:15:0:0:64:64:4:60:4:60|t %s is under attack!"
 --L.nextInvasions = "Next Invasions"
 --L.next = "Next"
 --L.waiting = "Waiting"

--- a/Locales/ruRU.lua
+++ b/Locales/ruRU.lua
@@ -4,7 +4,7 @@ local _, mod = ...
 local L = mod.L
 
 --L.firstRunWarning = "Timers will not be shown until you see your first invasion."
---L.underAttack = "|T236292:15:15:0:0:64:64:4:60:4:60|t %s is under attack!"
+--L.underAttack = "|T1044517:15:15:0:0:64:64:4:60:4:60|t %s is under attack!"
 --L.nextInvasions = "Next Invasions"
 --L.next = "Next"
 --L.waiting = "Waiting"

--- a/Locales/zhCN.lua
+++ b/Locales/zhCN.lua
@@ -4,7 +4,7 @@ local _, mod = ...
 local L = mod.L
 
 L.firstRunWarning = "遇到第一次入侵之前不会显示计时器。"
-L.underAttack = "|T236292:15:15:0:0:64:64:4:60:4:60|t %s 被入侵！"
+L.underAttack = "|T1044517:15:15:0:0:64:64:4:60:4:60|t %s 被入侵！"
 L.nextInvasions = "下次入侵"
 L.next = "下次"
 L.waiting = "等待中"

--- a/Locales/zhTW.lua
+++ b/Locales/zhTW.lua
@@ -4,7 +4,7 @@ local _, mod = ...
 local L = mod.L
 
 L.firstRunWarning = "計時器將在第一次遇到入侵之後顯示。"
-L.underAttack = "|T236292:15:15:0:0:64:64:4:60:4:60|t %s被入侵！"
+L.underAttack = "|T1044517:15:15:0:0:64:64:4:60:4:60|t %s被入侵！"
 L.nextInvasions = "下次入侵"
 L.next = "下次"
 L.waiting = "等待中"


### PR DESCRIPTION
* Use L.underAttack on the bar for an active assault.
* Use the garrison invasion icon in L.underAttack.
* Track WarMode status and provide appropriate achievement in tooltip.
* Proper assault order by adding BFAInvasionZone global:
    * Contains an index number while simply ordering all data tables. When an assault begins, BFAInvasionTime and BFAInvasionZone updates.
    * Track next zones using "nextzone = 6 and 1 or + 1" similar to how "t + 68400" tracked times.
    * Next zones in schedule tooltip and in bar, including icons.
    * Rearranged data tables to near top of file and combined the quest IDs into one table.
    * Changed assault icons to one of four: Alliance icons for Kul Tiras, Horde icons for Zandalar, blue background if player is Alliance, and red background if player is Horde.

Github's diff engine is ridiculous. It wasn't able to track the movement of the rearranged tables, so it thinks I replaced the whole file. If you have NotePad++ with the "Compare" plugin installed, you'll see my changes more clearly. The data table movement was to mainly cover icons and names being used before the original table spot.

As for tracking the zone of the last assault, I have not included a method of preventing errors for installs that have already seen an assault. I assume the error will be attempting to do arithmetic on nil. This can be manually fixed by using **/run BFAInvasionZone=1** and reloading, repeating up to 6 to get the right zone on the timer, or if you already know the zone you last saw that corresponds with BFAInvasionTime, just set it to that (Vol'dun==1).

Order is:
Vol'dun > Drustvar > Zuldazar > Tiragarde Sound > Nazmir > Stormsong Valley